### PR TITLE
Make script more resilient to user errors and missing setting values

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -1718,12 +1718,16 @@ function RayfieldLibrary:CreateWindow(Settings)
 			end
 
 			if DropdownSettings.MultipleOptions then
-				if #DropdownSettings.CurrentOption == 1 then
-					Dropdown.Selected.Text = DropdownSettings.CurrentOption[1]
-				elseif #DropdownSettings.CurrentOption == 0 then
-					Dropdown.Selected.Text = "None"
+				if DropdownSettings.CurrentOption then
+					if #DropdownSettings.CurrentOption == 1 then
+						Dropdown.Selected.Text = DropdownSettings.CurrentOption[1]
+					elseif #DropdownSettings.CurrentOption == 0 then
+						Dropdown.Selected.Text = "None"
+					else
+						Dropdown.Selected.Text = "Various"
+					end
 				else
-					Dropdown.Selected.Text = "Various"
+					Dropdown.Selected.Text = "None"
 				end
 			else
 				Dropdown.Selected.Text = DropdownSettings.CurrentOption[1]

--- a/source.lua
+++ b/source.lua
@@ -1718,7 +1718,7 @@ function RayfieldLibrary:CreateWindow(Settings)
 			end
 
 			if DropdownSettings.MultipleOptions then
-				if DropdownSettings.CurrentOption then
+				if DropdownSettings.CurrentOption and type(DropdownSettings.CurrentOption) == "table" then
 					if #DropdownSettings.CurrentOption == 1 then
 						Dropdown.Selected.Text = DropdownSettings.CurrentOption[1]
 					elseif #DropdownSettings.CurrentOption == 0 then
@@ -1726,7 +1726,8 @@ function RayfieldLibrary:CreateWindow(Settings)
 					else
 						Dropdown.Selected.Text = "Various"
 					end
-				else
+				else	
+					DropdownSettings.CurrentOption = {}
 					Dropdown.Selected.Text = "None"
 				end
 			else

--- a/source.lua
+++ b/source.lua
@@ -1709,17 +1709,16 @@ function RayfieldLibrary:CreateWindow(Settings)
 
 			Dropdown.List.Visible = false
 			if DropdownSettings.CurrentOption then
-				if typeof(DropdownSettings.CurrentOption) == "string" then
+				if type(DropdownSettings.CurrentOption) == "string" then
 					DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption}
 				end
-	
-				if not DropdownSettings.MultipleOptions then
+				if not DropdownSettings.MultipleOptions and type(DropdownSettings.CurrentOption) == "table" then
 					DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption[1]}
 				end
 			else
-				DropdownSettings.CurrentOption = "None"
+				DropdownSettings.CurrentOption = {"None"}
 			end
-			
+
 			if DropdownSettings.MultipleOptions then
 				if DropdownSettings.CurrentOption and type(DropdownSettings.CurrentOption) == "table" then
 					if #DropdownSettings.CurrentOption == 1 then

--- a/source.lua
+++ b/source.lua
@@ -1708,15 +1708,18 @@ function RayfieldLibrary:CreateWindow(Settings)
 			Dropdown.Parent = TabPage
 
 			Dropdown.List.Visible = false
-
-			if typeof(DropdownSettings.CurrentOption) == "string" then
-				DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption}
+			if DropdownSettings.CurrentOption then
+				if typeof(DropdownSettings.CurrentOption) == "string" then
+					DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption}
+				end
+	
+				if not DropdownSettings.MultipleOptions then
+					DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption[1]}
+				end
+			else
+				DropdownSettings.CurrentOption = "None"
 			end
-
-			if not DropdownSettings.MultipleOptions then
-				DropdownSettings.CurrentOption = {DropdownSettings.CurrentOption[1]}
-			end
-
+			
 			if DropdownSettings.MultipleOptions then
 				if DropdownSettings.CurrentOption and type(DropdownSettings.CurrentOption) == "table" then
 					if #DropdownSettings.CurrentOption == 1 then


### PR DESCRIPTION
Add a couple of statements to make sure that the required settings are set correctly by the user when creating dropdowns. If they're not, the script will fall back to a default setting instead of erroring.