### PR TITLE
Add ToggleUIKeybind setting to :CreateWindow()

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -1568,11 +1568,20 @@ function RayfieldLibrary:CreateWindow(Settings)
 			end)
 	end
 
-	if Settings.ToggleUIKeybind then
+	if Settings.ToggleUIKeybind then -- Can either be a string or an Enum.KeyCode
 		local keybind = Settings.ToggleUIKeybind
-		assert(type(Settings.ToggleUIKeybind) == "string", "ToggleUIKeybind must be a string")
-		assert(Enum.KeyCode[Settings.ToggleUIKeybind], "ToggleUIKeybind must be a valid KeyCode")
-		overrideSetting("General", "rayfieldOpen", keybind)
+		if type(keybind) == "string" then
+			keybind = string.upper(keybind)
+			assert(pcall(function()
+				return Enum.KeyCode[keybind]
+			end), "ToggleUIKeybind must be a valid KeyCode")
+			overrideSetting("General", "rayfieldOpen", keybind)
+		elseif typeof(keybind) == "EnumItem" then
+			assert(keybind.EnumType == Enum.KeyCode, "ToggleUIKeybind must be a KeyCode enum")
+			overrideSetting("General", "rayfieldOpen", keybind.Name)
+		else
+			error("ToggleUIKeybind must be a string or KeyCode enum")
+		end
 	end
 
 	if isfolder and not isfolder(RayfieldFolder) then


### PR DESCRIPTION
- This allows the script developer to override the keybind for toggling the UI. Particularly useful for scripts that use the same keybind as the default UI toggle. The setting can be specified either as a string or `Enum.KeyCode`.

    If ToggleUIKeybind is set, it will be used instead of the keybind stored in the user's configuration file. If the user then changes the keybind via the settings menu, the override will be removed and the new keybind will be used and saved as ususal.

- The override system can be used to override any setting that is configurable by the user.

- Also set the user-facing toggle for usageAnalytics to false if requests have already been disabled by the developer.