### PR TITLE
Fix error when calling Rayfield:Destory() through button (issue #24 & #25)

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -623,6 +623,7 @@ local buildAttempts = 0
 local correctBuild = false
 local warned
 local globalLoaded
+local rayfieldDestroyed = false -- True when RayfieldLibrary:Destroy() is called
 
 repeat
 	if Rayfield:FindFirstChild('Build') and Rayfield.Build.Value == InterfaceBuild then
@@ -2048,6 +2049,10 @@ function RayfieldLibrary:CreateWindow(Settings)
 
 			Button.Interact.MouseButton1Click:Connect(function()
 				local Success, Response = pcall(ButtonSettings.Callback)
+				-- Prevents animation from trying to play if the button's callback called RayfieldLibrary:Destroy()
+				if rayfieldDestroyed then
+					return
+				end
 				if not Success then
 					TweenService:Create(Button, TweenInfo.new(0.6, Enum.EasingStyle.Exponential), {BackgroundColor3 = Color3.fromRGB(85, 0, 0)}):Play()
 					TweenService:Create(Button.ElementIndicator, TweenInfo.new(0.6, Enum.EasingStyle.Exponential), {TextTransparency = 1}):Play()
@@ -3510,6 +3515,7 @@ end
 
 local hideHotkeyConnection -- Has to be initialized here since the connection is made later in the script
 function RayfieldLibrary:Destroy()
+	rayfieldDestroyed = true
 	hideHotkeyConnection:Disconnect()
 	Rayfield:Destroy()
 end


### PR DESCRIPTION
This happened when a button's callback called Rayfield:Destroy() and Rayfield attempted to play an animation/tween after being destroyed.

Fixes  #24 , fixes #25