### PR TITLE
Remove unnecessary print statement when creating window

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -1564,7 +1564,6 @@ end
 
 
 function RayfieldLibrary:CreateWindow(Settings)
-	print('creating window')
 	if Rayfield:FindFirstChild('Loading') then
 		if getgenv and not getgenv().rayfieldCached then
 			Rayfield.Enabled = true


### PR DESCRIPTION
This print statement should be removed as it serves no functional purpose and will only clutter the console output.