### PR TITLE
Disconnect keybind connections on Rayfield:Destroy() [From #36]

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -752,6 +752,7 @@ local Hidden = false
 local Debounce = false
 local searchOpen = false
 local Notifications = Rayfield.Notifications
+local keybindConnections = {} -- For storing keybind connections to disconnect when Rayfield is destroyed
 
 local SelectedTheme = RayfieldLibrary.Theme.Default
 
@@ -3048,7 +3049,7 @@ function RayfieldLibrary:CreateWindow(Settings)
 				TweenService:Create(Keybind, TweenInfo.new(0.6, Enum.EasingStyle.Exponential), {BackgroundColor3 = SelectedTheme.ElementBackground}):Play()
 			end)
 
-			UserInputService.InputBegan:Connect(function(input, processed)
+			local connection = UserInputService.InputBegan:Connect(function(input, processed)
 				if CheckingForKey then
 					if input.KeyCode ~= Enum.KeyCode.Unknown then
 						local SplitMessage = string.split(tostring(input.KeyCode), ".")
@@ -3102,6 +3103,7 @@ function RayfieldLibrary:CreateWindow(Settings)
 					end
 				end
 			end)
+			table.insert(keybindConnections, connection)
 
 			Keybind.KeybindFrame.KeybindBox:GetPropertyChangedSignal("Text"):Connect(function()
 				TweenService:Create(Keybind.KeybindFrame, TweenInfo.new(0.55, Enum.EasingStyle.Exponential, Enum.EasingDirection.Out), {Size = UDim2.new(0, Keybind.KeybindFrame.KeybindBox.TextBounds.X + 24, 0, 30)}):Play()
@@ -3584,6 +3586,9 @@ local hideHotkeyConnection -- Has to be initialized here since the connection is
 function RayfieldLibrary:Destroy()
 	rayfieldDestroyed = true
 	hideHotkeyConnection:Disconnect()
+	for _, connection in keybindConnections do
+		connection:Disconnect()
+	end
 	Rayfield:Destroy()
 end
 


### PR DESCRIPTION
Disconnect all keybind connections when Rayfield is destroyed.

This is an improved and fixed version of PR #36. Props to @samerop for the original.