### PR TITLE
Create callSafely() wrapper to mitigate filesystem function errors

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -131,11 +131,11 @@ end
 
 -- The function below provides a safe alternative for calling error-prone functions
 -- Especially useful for filesystem function (writefile, makefolder, etc.)
-local function callSafely(func, arguments)
+local function callSafely(func, ...)
 	if func then
-		local success, result = pcall(func, arguments)
+		local success, result = pcall(func, ...)
 		if not success then
-			warn("Function failed with error: ", result)
+			warn("Rayfield | Function failed with error: ", result)
 			return false
 		else
 			return result


### PR DESCRIPTION
Create a callSafely function which calls the provided function with
pcall. This is especially useful for filesystem functions, which can
sometimes fail due to poor implementation by executors,
lacking permissions, or other factors.

All calls of filesystem functions (writefile, isfile, readfile,
isfolder, and makefolder) have been changed to use callSafely. This
will prevent any trivial errors from stopping the execution Rayfield.

Add ensureFolder function which safely checks if a folder exists and
creates it if it doesn't.